### PR TITLE
Use statically typed `DynamicJsonResponse.ToObject<T>`

### DIFF
--- a/bucket.manager/bucket.manager.csproj
+++ b/bucket.manager/bucket.manager.csproj
@@ -77,8 +77,8 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autodesk.Forge, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Autodesk.Forge.1.4.0\lib\net452\Autodesk.Forge.dll</HintPath>
+    <Reference Include="Autodesk.Forge, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Autodesk.Forge.1.7.0\lib\net452\Autodesk.Forge.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/bucket.manager/packages.config
+++ b/bucket.manager/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autodesk.Forge" version="1.4.0" targetFramework="net46" />
+  <package id="Autodesk.Forge" version="1.7.0" targetFramework="net46" />
   <package id="cef.redist.x64" version="3.2987.1601" targetFramework="net452" />
   <package id="cef.redist.x86" version="3.2987.1601" targetFramework="net452" />
   <package id="CefSharp.Common" version="57.0.0" targetFramework="net452" />


### PR DESCRIPTION
* Therefore update Autodesk.Forge-nuget Package to 1.7

The new Package brings the method `ToObject<T>()`, which converts `DynamicJsonResponse` to statically typed objects. With this, accessing results of Forge Api calls is simpler and checked by compiler.